### PR TITLE
Bumps bootlint dependency, adding line/column nums

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -35,8 +35,7 @@ module.exports = function(grunt) {
         },
         files: {
           'tmp/default_options': [
-            'test/fixtures/missing-doctype.html',
-            'test/fixtures/missing-charset.html',
+            'test/fixtures/**.html',
           ]
         }
       },

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "test": "grunt test"
   },
   "dependencies": {
-    "bootlint": "^0.7.0",
+    "bootlint": "^0.8.0",
     "chalk": "^0.5.1"
   },
   "devDependencies": {

--- a/tasks/bootlint.js
+++ b/tasks/bootlint.js
@@ -12,29 +12,16 @@ module.exports = function(grunt) {
   var bootlint = require('bootlint');
   var chalk = require('chalk');
 
-  var msg = {
-    start: 'Validation started for ',
-    ok: 'Validation successful!',
-    done: 'No Bootlint errors!'.bold
-  };
 
   grunt.registerMultiTask('bootlint', 'An HTML linter for Bootstrap projects', function() {
     var options = this.options({
       stoponerror: false,
       relaxerror: []
     });
+
     var totalErrCount = 0;
-
-    var reporter = function(lint) {
-      var lintId = (lint.id[0] === 'E') ? chalk.bgGreen.white(lint.id) : chalk.bgRed.white(lint.id);
-      if (options.stoponerror) {
-        grunt.fail.warn(lintId, lint.message);
-      } else {
-        grunt.log.warn(lintId, lint.message);
-        totalErrCount++;
-      }
-    };
-
+    var totalFileCount = 0;
+    var hardfail = false;
 
     // Iterate over all specified file groups.
     this.files.forEach(function(f) {
@@ -49,16 +36,38 @@ module.exports = function(grunt) {
 
       })
       .forEach(function(filepath) {
+
         var src = grunt.file.read(filepath);
-        grunt.log.writeln(msg.start + filepath);
+        var reporter = function (lint) {
+          var lintId = (lint.id[0] === 'E') ? chalk.bgGreen.white(lint.id) : chalk.bgRed.white(lint.id);
+          var output = false;
+          if (lint.elements) {
+            lint.elements.each(function (_, element) {
+              var loc = element.startLocation;
+              grunt.log.warn(filepath + ":" + (loc.line + 1) + ":" + (loc.column + 1), lintId, lint.message);
+              totalErrCount++;
+              output = true;
+            });
+          }
+          if (!output) {
+            grunt.log.warn(filepath + ":", lintId, lint.message);
+            totalErrCount++;
+            if (options.stoponerror) {
+              hardfail = true;
+            }
+          }
+        };
+
         bootlint.lintHtml(src, reporter, options.relaxerror);
+        totalFileCount++;
       });
 
       if (totalErrCount > 0) {
-        grunt.log.writeln().fail(totalErrCount + ' lint errors found.');
+        grunt.log.writeln().fail(totalErrCount + " lint error(s) found across " + totalFileCount + " file(s).");
         grunt.log.writeln().fail('For details, look up the lint problem IDs in the Bootlint wiki: https://github.com/twbs/bootlint/wiki');
-      } else {
-        grunt.log.writeln().success(msg.done);
+        if (hardfail) {
+          grunt.fail.warn('Too many bootlint errors.');
+        }
       }
     });
   });

--- a/test/bootlint_test.js
+++ b/test/bootlint_test.js
@@ -28,19 +28,17 @@ exports.bootlint = {
     done();
   },
   default_options: function(test) {
-    test.expect(4);
+    test.expect(3);
     grunt.util.spawn({
       grunt: true,
       args: ['bootlint:default_options', '--no-color'],
     }, function(err, result) {
-      test.ok(result.stdout.indexOf("Validation started for") >= 0,
-        'Should print start msg');
       test.ok(result.stdout.indexOf("test/fixtures/missing-doctype.html") >= 0,
         'Should print file path');
       test.ok(result.stdout.indexOf("Document is missing a DOCTYPE declaration") >= 0,
         'Should warn about missing a DOCTYPE');
-      test.ok(result.stdout.indexOf("2 lint errors found") >= 0,
-        'Should print number of lint errors');
+      test.ok(result.stdout.indexOf("8 lint error(s) found across 4 file(s)") >= 0,
+        'Should print number of lint errors and files');
       test.done();
     });
   },
@@ -52,20 +50,9 @@ exports.bootlint = {
     }, function(err, result) {
       test.ok(result.stdout.indexOf("Document is missing a DOCTYPE declaration") === -1,
         'Should not warn about missing a DOCTYPE');
-      test.ok(result.stdout.indexOf("1 lint errors found") >= 0,
-        'Should print correct number of lint errors');
+      test.ok(result.stdout.indexOf("1 lint error(s) found across 2 file(s)") >= 0,
+        'Should print correct number of lint errors and files');
       test.done();
     });
-  },
-  pass: function(test) {
-    test.expect(1);
-    grunt.util.spawn({
-      grunt: true,
-      args: ['bootlint:pass', '--no-color'],
-    }, function(err, result) {
-      test.ok(result.stdout.indexOf("No Bootlint errors!") >= 0,
-        'Should print "No Bootlint errors!" message');
-      test.done();
-    });
-  },
+  }
 };

--- a/test/fixtures/cols-redundant.html
+++ b/test/fixtures/cols-redundant.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8" />
+        <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <title>Test</title>
+        <!--[if lt IE 9]>
+            <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
+            <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
+        <![endif]-->
+        <script src="../../lib/jquery.min.js"></script>
+
+        <link rel="stylesheet" href="../../lib/qunit.css">
+        <script src="../../lib/qunit.js"></script>
+        <script src="../../../dist/browser/bootlint.js"></script>
+        <script src="../generic-qunit.js"></script>
+    </head>
+    <body>
+        <div class="container">
+            <div class="row">
+                <div class="abc col-xs-2 def col-sm-1 ghi col-md-1 jkl col-lg-1">Single-digit columns; sm-lg redundant; random classes interleaved</div>
+            </div>
+            <div class="row">
+                <div class="col-xs-10 abc col-sm-10 def col-md-10 ghi col-lg-12 jkl">Double-digit columns; xs-md redundant; random classes interleaved</div>
+            </div>
+            <div class="row">
+                <div class="col-xs-6 col-sm-6 col-md-6 col-lg-6">xs-lg redundant</div>
+            </div>
+            <div class="row">
+                <div class="col-xs-5 col-sm-5">xs-sm redundant</div>
+            </div>
+            <div class="row">
+                <div class="col-sm-4 col-md-4">sm-md redundant</div>
+            </div>
+            <div class="row">
+                <div class="col-md-3 col-lg-3">md-lg redundant</div>
+            </div>
+        </div>
+
+        <div id="qunit"></div>
+        <ol id="bootlint">
+            <li data-lint='Since grid classes apply to devices with screen widths greater than or equal to the breakpoint sizes (unless overridden by grid classes targeting larger screens), `class="abc col-xs-2 def col-sm-1 ghi col-md-1 jkl col-lg-1"` is redundant and can be simplified to `class="abc def ghi jkl col-xs-2 col-sm-1"`'></li>
+            <li data-lint='Since grid classes apply to devices with screen widths greater than or equal to the breakpoint sizes (unless overridden by grid classes targeting larger screens), `class="col-xs-10 abc col-sm-10 def col-md-10 ghi col-lg-12 jkl"` is redundant and can be simplified to `class="abc def ghi jkl col-xs-10 col-lg-12"`'></li>
+            <li data-lint='Since grid classes apply to devices with screen widths greater than or equal to the breakpoint sizes (unless overridden by grid classes targeting larger screens), `class="col-xs-6 col-sm-6 col-md-6 col-lg-6"` is redundant and can be simplified to `class="col-xs-6"`'></li>
+            <li data-lint='Since grid classes apply to devices with screen widths greater than or equal to the breakpoint sizes (unless overridden by grid classes targeting larger screens), `class="col-xs-5 col-sm-5"` is redundant and can be simplified to `class="col-xs-5"`'></li>
+            <li data-lint='Since grid classes apply to devices with screen widths greater than or equal to the breakpoint sizes (unless overridden by grid classes targeting larger screens), `class="col-sm-4 col-md-4"` is redundant and can be simplified to `class="col-sm-4"`'></li>
+            <li data-lint='Since grid classes apply to devices with screen widths greater than or equal to the breakpoint sizes (unless overridden by grid classes targeting larger screens), `class="col-md-3 col-lg-3"` is redundant and can be simplified to `class="col-md-3"`'></li>
+        </ol>
+    </body>
+</html>


### PR DESCRIPTION
Also cleans up quite a bit of the noisiness from the output. It will now pass silently and will only print when there are warnings or errors.

Closes #26
Refs: #27, https://github.com/zacechola/grunt-bootlint/commit/4d4c31c16e0ca3384654edab84e2eb68faf54e07#commitcomment-8306421

cc: @XhmikosR, @cvrebert, @mischah
