### PR TITLE
fixed stoponerror option not stopping grunt task

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ grunt.initConfig({
 * Type: `Boolean`
 * Default: `false`
 
-Breaks out of grunt task on first error. Use `--force` to force continue.
+Breaks out of grunt task if there are errors. Use `--force` to force continue.
 
 #### options.relaxerror
 

--- a/tasks/bootlint.js
+++ b/tasks/bootlint.js
@@ -21,7 +21,6 @@ module.exports = function(grunt) {
 
     var totalErrCount = 0;
     var totalFileCount = 0;
-    var hardfail = false;
 
     // Iterate over all specified file groups.
     this.files.forEach(function(f) {
@@ -52,9 +51,6 @@ module.exports = function(grunt) {
           if (!output) {
             grunt.log.warn(filepath + ":", lintId, lint.message);
             totalErrCount++;
-            if (options.stoponerror) {
-              hardfail = true;
-            }
           }
         };
 
@@ -65,7 +61,7 @@ module.exports = function(grunt) {
       if (totalErrCount > 0) {
         grunt.log.writeln().fail(totalErrCount + " lint error(s) found across " + totalFileCount + " file(s).");
         grunt.log.writeln().fail('For details, look up the lint problem IDs in the Bootlint wiki: https://github.com/twbs/bootlint/wiki');
-        if (hardfail) {
+        if (options.stoponerror) {
           grunt.fail.warn('Too many bootlint errors.');
         }
       } else {


### PR DESCRIPTION
grunt task wasn't exiting if errors were found and stoponerror was set - would continue running. hardfail wasn't set to true in the case where output was true.
