### PR TITLE
Update license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,12 +11,7 @@
   "bugs": {
     "url": "https://github.com/twbs/grunt-bootlint/issues"
   },
-  "license": [
-    {
-      "type": "MIT",
-      "url": "https://github.com/twbs/grunt-bootlint/blob/master/LICENSE-MIT"
-    }
-  ],
+  "license": "MIT",
   "keywords": [
     "gruntplugin",
     "bootstrap",


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license