### PR TITLE
Travis: replace `stable` by `5`.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 language: node_js
 node_js:
-  - "stable"
+  - "5"
   - "4"
   - "0.12"
   - "0.10"


### PR DESCRIPTION
One would expect `stable` to use 5.1.0 now that is out but that's not the case.

/CC @twbs/bootlint 